### PR TITLE
Add compile-time debug guards

### DIFF
--- a/env/axi4_env.sv
+++ b/env/axi4_env.sv
@@ -68,6 +68,9 @@ endfunction : new
 //--------------------------------------------------------------------------------------------
 function void axi4_env::build_phase(uvm_phase phase);
   super.build_phase(phase);
+`ifdef UVM_DBG
+  `uvm_info(get_type_name(), "DEBUG: build_phase", UVM_DEBUG)
+`endif
   
   if(!uvm_config_db #(axi4_env_config)::get(this,"","axi4_env_config",axi4_env_cfg_h)) begin
     `uvm_fatal("FATAL_ENV_AGENT_CONFIG", $sformatf("Couldn't get the env_agent_config from config_db"))
@@ -125,6 +128,9 @@ endfunction : build_phase
 //--------------------------------------------------------------------------------------------
 function void axi4_env::connect_phase(uvm_phase phase);
   super.connect_phase(phase);
+`ifdef UVM_DBG
+  `uvm_info(get_type_name(), "DEBUG: connect_phase", UVM_DEBUG)
+`endif
 
   if(axi4_env_cfg_h.has_virtual_seqr) begin
     foreach(axi4_master_agent_h[i]) begin

--- a/env/axi4_scoreboard.sv
+++ b/env/axi4_scoreboard.sv
@@ -254,6 +254,9 @@ endfunction : start_of_simulation_phase
 task axi4_scoreboard::run_phase(uvm_phase phase);
 
   super.run_phase(phase);
+`ifdef UVM_DBG
+  `uvm_info(get_type_name(), "DEBUG: run_phase", UVM_DEBUG)
+`endif
 
   fork
     axi4_write_address();

--- a/master/axi4_master_agent.sv
+++ b/master/axi4_master_agent.sv
@@ -63,6 +63,9 @@ endfunction : new
 //--------------------------------------------------------------------------------------------
 function void axi4_master_agent::build_phase(uvm_phase phase);
   super.build_phase(phase);
+`ifdef UVM_DBG
+  `uvm_info(get_type_name(), "DEBUG: build_phase", UVM_DEBUG)
+`endif
   
   if(axi4_master_agent_cfg_h.is_active == UVM_ACTIVE) begin
     axi4_master_drv_proxy_h=axi4_master_driver_proxy::type_id::create("axi4_master_drv_proxy_h",this);
@@ -90,6 +93,9 @@ endfunction : build_phase
 //--------------------------------------------------------------------------------------------
 function void axi4_master_agent::connect_phase(uvm_phase phase);
   super.connect_phase(phase);
+`ifdef UVM_DBG
+  `uvm_info(get_type_name(), "DEBUG: connect_phase", UVM_DEBUG)
+`endif
   if(axi4_master_agent_cfg_h.is_active == UVM_ACTIVE) begin
     axi4_master_drv_proxy_h.axi4_master_agent_cfg_h = axi4_master_agent_cfg_h;
     axi4_master_write_seqr_h.axi4_master_agent_cfg_h = axi4_master_agent_cfg_h;

--- a/master/axi4_master_driver_proxy.sv
+++ b/master/axi4_master_driver_proxy.sv
@@ -158,6 +158,9 @@ endfunction : end_of_elaboration_phase
 //  phase - uvm phase
 //--------------------------------------------------------------------------------------------
 task axi4_master_driver_proxy::run_phase(uvm_phase phase);
+`ifdef UVM_DBG
+  `uvm_info(get_type_name(), "DEBUG: run_phase", UVM_DEBUG)
+`endif
 
   //waiting for system reset
   axi4_master_drv_bfm_h.wait_for_aresetn();

--- a/slave/axi4_slave_agent.sv
+++ b/slave/axi4_slave_agent.sv
@@ -62,6 +62,9 @@ endfunction : new
 //--------------------------------------------------------------------------------------------
 function void axi4_slave_agent::build_phase(uvm_phase phase);
   super.build_phase(phase);
+`ifdef UVM_DBG
+  `uvm_info(get_type_name(), "DEBUG: build_phase", UVM_DEBUG)
+`endif
 
    if(axi4_slave_agent_cfg_h.is_active == UVM_ACTIVE) begin
      axi4_slave_drv_proxy_h  = axi4_slave_driver_proxy::type_id::create("axi4_slave_drv_proxy_h",this);
@@ -85,6 +88,9 @@ endfunction : build_phase
 //--------------------------------------------------------------------------------------------
 function void axi4_slave_agent::connect_phase(uvm_phase phase);
   super.connect_phase(phase);
+`ifdef UVM_DBG
+  `uvm_info(get_type_name(), "DEBUG: connect_phase", UVM_DEBUG)
+`endif
   
   if(axi4_slave_agent_cfg_h.is_active == UVM_ACTIVE) begin
     axi4_slave_drv_proxy_h.axi4_slave_agent_cfg_h  = axi4_slave_agent_cfg_h;

--- a/slave/axi4_slave_driver_proxy.sv
+++ b/slave/axi4_slave_driver_proxy.sv
@@ -146,6 +146,9 @@ endfunction  : end_of_elaboration_phase
 task axi4_slave_driver_proxy::run_phase(uvm_phase phase);
 
   `uvm_info(get_type_name(),"SLAVE_DRIVER_PROXY",UVM_MEDIUM)
+`ifdef UVM_DBG
+  `uvm_info(get_type_name(), "DEBUG: run_phase", UVM_DEBUG)
+`endif
 
   //wait for system reset
   axi4_slave_drv_bfm_h.wait_for_system_reset();

--- a/virtual_seq/axi4_virtual_write_read_seq.sv
+++ b/virtual_seq/axi4_virtual_write_read_seq.sv
@@ -82,6 +82,11 @@ task axi4_virtual_write_read_seq::body();
     end
     begin : T1_NBK_SL_WR
       for (int i = 0; i < 5; i++) begin
+`ifdef UVM_DBG
+        `uvm_info(get_type_name(),
+                  $sformatf("Waiting for bk_sl_wr_done before NBK_SL_WR iteration %0d", i),
+                  UVM_DEBUG)
+`endif
         @(bk_sl_wr_done);
         `uvm_info(get_type_name(), $sformatf("NBK_SL_WR iteration %0d", i), UVM_LOW)
 
@@ -100,6 +105,11 @@ task axi4_virtual_write_read_seq::body();
     begin : T2_NBK_SL_RD
 
       for (int i = 0; i < 3; i++) begin
+`ifdef UVM_DBG
+        `uvm_info(get_type_name(),
+                  $sformatf("Waiting for bk_sl_rd_done before NBK_SL_RD iteration %0d", i),
+                  UVM_DEBUG)
+`endif
         @(bk_sl_rd_done);
 
         `uvm_info(get_type_name(), $sformatf("NBK_SL_RD iteration %0d", i), UVM_LOW)
@@ -118,6 +128,11 @@ task axi4_virtual_write_read_seq::body();
     end
     begin: T1_NBK_WRITE
       for (int i = 0; i < 5; i++) begin
+`ifdef UVM_DBG
+        `uvm_info(get_type_name(),
+                  $sformatf("Waiting for bk_mst_wr_done before NBK_WRITE iteration %0d", i),
+                  UVM_DEBUG)
+`endif
         @(bk_mst_wr_done);
         `uvm_info(get_type_name(), $sformatf("NBK_WRITE iteration %0d", i), UVM_LOW)
         axi4_master_nbk_write_seq_h.start(p_sequencer.axi4_master_write_seqr_h);
@@ -135,6 +150,11 @@ task axi4_virtual_write_read_seq::body();
     begin: T2_NBK_READ
 
       for (int i = 0; i < 3; i++) begin
+`ifdef UVM_DBG
+        `uvm_info(get_type_name(),
+                  $sformatf("Waiting for bk_mst_rd_done before NBK_READ iteration %0d", i),
+                  UVM_DEBUG)
+`endif
         @(bk_mst_rd_done);
 
         `uvm_info(get_type_name(), $sformatf("NBK_READ iteration %0d", i), UVM_LOW)

--- a/virtual_seqr/axi4_virtual_sequencer.sv
+++ b/virtual_seqr/axi4_virtual_sequencer.sv
@@ -100,6 +100,9 @@ endfunction : start_of_simulation_phase
 //  phase - uvm phase
 //--------------------------------------------------------------------------------------------
 task axi4_virtual_sequencer::run_phase(uvm_phase phase);
+`ifdef UVM_DBG
+  `uvm_info(get_type_name(), "DEBUG: run_phase", UVM_DEBUG)
+`endif
 
   // Work here
   // ...


### PR DESCRIPTION
## Summary
- use `UVM_DBG` macro around recently added debug `uvm_info` calls
- compile with `+define+UVM_DBG` to see the extra debug output

## Testing
- `make sim test=axi4_write_read_test` *(fails: `vcs` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4f2cc9108320bf773995e39fc076