### PR TITLE
Improve custom AXI error tests

### DIFF
--- a/test/custom/tc_028_test.sv
+++ b/test/custom/tc_028_test.sv
@@ -18,6 +18,14 @@ task tc_028_test::run_phase(uvm_phase phase);
   tc_seq_h = axi4_virtual_tc028_seq::type_id::create("tc_seq_h");
   phase.raise_objection(this);
   tc_seq_h.start(axi4_env_h.axi4_virtual_seqr_h);
+  // Wait until the scoreboard processes the write response
+  time wait_start = $time;
+  `uvm_info("TC028", $sformatf("Waiting for scoreboard response @ %0t", wait_start), UVM_LOW)
+  wait (axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_bresp_count > 0);
+  `uvm_info("TC028", $sformatf("Scoreboard responded after %0t", $time - wait_start), UVM_LOW)
+  if(axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_h3.bresp != WRITE_DECERR)
+    `uvm_error("TC028", $sformatf("Expected DECERR but got %s",
+                           axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_h3.bresp.name()))
   phase.drop_objection(this);
 endtask : run_phase
 

--- a/test/custom/tc_029_test.sv
+++ b/test/custom/tc_029_test.sv
@@ -19,6 +19,14 @@ task tc_029_test::run_phase(uvm_phase phase);
   tc_seq_h = axi4_virtual_tc029_seq::type_id::create("tc_seq_h");
   phase.raise_objection(this);
   tc_seq_h.start(axi4_env_h.axi4_virtual_seqr_h);
+  // Wait until the scoreboard processes the write response
+  time wait_start = $time;
+  `uvm_info("TC029", $sformatf("Waiting for scoreboard response @ %0t", wait_start), UVM_LOW)
+  wait (axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_bresp_count > 0);
+  `uvm_info("TC029", $sformatf("Scoreboard responded after %0t", $time - wait_start), UVM_LOW)
+  if(axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_h3.bresp != WRITE_SLVERR)
+    `uvm_error("TC029", $sformatf("Expected SLVERR but got %s",
+                           axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_h3.bresp.name()))
   phase.drop_objection(this);
 endtask : run_phase
 

--- a/test/custom/tc_034_test.sv
+++ b/test/custom/tc_034_test.sv
@@ -21,6 +21,14 @@ task tc_034_test::run_phase(uvm_phase phase);
   // Preload address outside the valid range so the scoreboard has data
   axi4_env_h.axi4_scoreboard_h.preload_memory(0, 32'h00002000, 32'hDEAD_BEEF);
   tc_seq_h.start(axi4_env_h.axi4_virtual_seqr_h);
+  // Wait for the scoreboard to process the read response
+  time wait_start = $time;
+  `uvm_info("TC034", $sformatf("Waiting for scoreboard response @ %0t", wait_start), UVM_LOW)
+  wait (axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_rresp_count > 0);
+  `uvm_info("TC034", $sformatf("Scoreboard responded after %0t", $time - wait_start), UVM_LOW)
+  if(axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_h5.rresp[0] != READ_DECERR)
+    `uvm_error("TC034", $sformatf("Expected DECERR but got %s",
+                           axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_h5.rresp[0].name()))
   phase.drop_objection(this);
 endtask : run_phase
 

--- a/test/custom/tc_035_test.sv
+++ b/test/custom/tc_035_test.sv
@@ -21,6 +21,14 @@ task tc_035_test::run_phase(uvm_phase phase);
   // Preload unaligned address for read check
   axi4_env_h.axi4_scoreboard_h.preload_memory(0, 32'h00001001, 32'hFACE1001);
   tc_seq_h.start(axi4_env_h.axi4_virtual_seqr_h);
+  // Wait for the scoreboard to process the read response
+  time wait_start = $time;
+  `uvm_info("TC035", $sformatf("Waiting for scoreboard response @ %0t", wait_start), UVM_LOW)
+  wait (axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_rresp_count > 0);
+  `uvm_info("TC035", $sformatf("Scoreboard responded after %0t", $time - wait_start), UVM_LOW)
+  if(axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_h5.rresp[0] != READ_SLVERR)
+    `uvm_error("TC035", $sformatf("Expected SLVERR but got %s",
+                           axi4_env_h.axi4_scoreboard_h.axi4_slave_tx_h5.rresp[0].name()))
   phase.drop_objection(this);
 endtask : run_phase
 


### PR DESCRIPTION
## Summary
- wait for scoreboard before validating DECERR in TC_028 and log wait time
- wait for scoreboard before validating SLVERR in TC_029 and log wait time
- wait for scoreboard before checking DECERR in TC_034 and log wait time
- wait for scoreboard before checking SLVERR in TC_035 and log wait time

## Testing
- `make -C sim/questasim compile` *(fails: vlib not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a1dbdd87c8320b4b99bc29d6adc0d